### PR TITLE
Add translation: ILoveSlicksters

### DIFF
--- a/src/ILoveSlicksters/translations/zh_CN.po
+++ b/src/ILoveSlicksters/translations/zh_CN.po
@@ -1,0 +1,381 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Application: Oxygen Not IncludedPOT Version: 2.0\n"
+"X-Generator: Poedit 3.6\n"
+
+#. ILoveSlicksters.PHO_STRINGS.DROWNING.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.DROWNING.NAME"
+msgid "Drowning"
+msgstr "溺水"
+
+#. ILoveSlicksters.PHO_STRINGS.DROWNING.TOOLTIP
+msgctxt "ILoveSlicksters.PHO_STRINGS.DROWNING.TOOLTIP"
+msgid "This critter can't breathe in <style=\"KKeyword\">Air</style>!"
+msgstr "这种小动物无法在<style=\"KKeyword\">空气</style> 中呼吸！"
+
+#. ILoveSlicksters.PHO_STRINGS.ELEMENTS.ANTIGEL.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.ELEMENTS.ANTIGEL.DESC"
+msgid ""
+"A mixture of water(H<sub>2</sub>O) and Ethylen Glycol (C<sub>2</sub>H<sub>6</"
+"sub>O<sub>2</sub>).\n"
+"\n"
+"It has been designed by engineers to be a good heat transfer fluid that does "
+"not freeze or vaporize easily."
+msgstr ""
+"水（H<sub>2</sub>O）和乙二醇（C<sub>2</sub>H<sub>6</sub>O<sub>2</sub>）的混合"
+"物。\n"
+"\n"
+"工程师将其设计为一种良好的传热流体，不易结冰或汽化。"
+
+#. ILoveSlicksters.PHO_STRINGS.ELEMENTS.ANTIGEL.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.ELEMENTS.ANTIGEL.NAME"
+msgid "<link=\"ANTIGEL\">Antigel</link>"
+msgstr "<link=\"ANTIGEL\">抗冻剂</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.ELEMENT.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.ELEMENT.DESC"
+msgid "Is immersed in {0}."
+msgstr "浸没在 {0} 中。"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.ELEMENT.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.ELEMENT.NAME"
+msgid "Element"
+msgstr "元素"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.LIGHT.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.LIGHT.DESC"
+msgid "Is in the light."
+msgstr "处于光照中。"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.LIGHT.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.LIGHT.NAME"
+msgid "Light"
+msgstr "光照"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.PRESSURE.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.PRESSURE.DESC"
+msgid "Is in air pressure below {0} g."
+msgstr "气压低于 {0} g。"
+
+#. ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.PRESSURE.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.FERTILITY_MODIFIERS.PRESSURE.NAME"
+msgid "Pressure"
+msgstr "气压"
+
+#. ILoveSlicksters.PHO_STRINGS.INAQUARIUM.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.INAQUARIUM.NAME"
+msgid "In an aquarium"
+msgstr "在一个水族箱中"
+
+#. ILoveSlicksters.PHO_STRINGS.NOTINAQUARIUM.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.NOTINAQUARIUM.NAME"
+msgid "Not in an aquarium"
+msgstr "不在一个水族箱中"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.BABY.DESC"
+msgid ""
+"A goopy little Aqua Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the <link=\"AQUAOILFLOATER\">Aqua "
+"Slickster</link>."
+msgstr ""
+"一只黏糊糊的水栖浮油生物幼崽。\n"
+"\n"
+"\n"
+"一天，它会长成成年形态，即 <link=“AQUAOILFLOATER”>水栖浮油生物</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.BABY.NAME"
+msgid "<link=\"AQUAOILFLOATER\">Aqua Larva</link>"
+msgstr "<link=\"AQUAOILFLOATER\">水栖浮油生物幼崽</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.DESC"
+msgid ""
+"<b><color=#2630D3FF>Aqua Slicksters</color></b> are aquatic critters that "
+"live in any water and consume any water.\n"
+"\n"
+"The <b><color=#2630D3FF>Aqua slickster</color></b> is a prehistoric strain "
+"of slickster when it was still living underwater. It is appreciated by the "
+"duplicants because it requires little maintenance of its "
+"<b><color=#2630D3FF>aquarium</color></b>."
+msgstr ""
+"<b><color=#2630D3FF>水栖浮油生物</b>是一种水生的小动物，可以生活在任何类型的"
+"水体中，并消耗所有类型的水。\n"
+"\n"
+"<b><color=#2630D3FF>水栖浮油生物</b>是浮油生物在史前时期仍生活在水下时的一个"
+"亚种。由于它的<b><color=#2630D3FF>水族箱</color></b>几乎不需要维护，因此受到"
+"复制人们的喜爱。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.EGG_NAME"
+msgid "<link=\"AQUAOILFLOATER\">Aqua Slickster Egg</link>"
+msgstr "<link=\"AQUAOILFLOATER\">水栖浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_AQUA.NAME"
+msgid "<link=\"AQUAOILFLOATER\">Aqua Slickster</link>"
+msgstr "<link=\"AQUAOILFLOATER\">水栖浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.BABY.DESC"
+msgid ""
+"A goopy little Ethanol Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the "
+"<link=\"ETHANOLOILFLOATER\">Ethanol Slickster</link>."
+msgstr ""
+"一只黏糊糊的乙醇浮油生物幼崽。\n"
+"\n"
+"有一天它会成长为成年形态，<link=“ETHANOLOILFLOATER”>乙醇浮油生物。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.BABY.NAME"
+msgid "<link=\"ETHANOLOILFLOATER\">Ethanol Larva</link>"
+msgstr "<link=\"ETHANOLOILFLOATER\">乙醇浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.DESC"
+msgid ""
+"Ehtanol Slicksters are slimy critters that consume "
+"<link=\"CARBONDIOXIDE\">Carbon Dioxide</link> and exude "
+"<link=\"ETHANOL\">Ethanol</link>.\n"
+"\n"
+"The ethanol slickster has adapted to a cold environment rich in carbon "
+"dioxide unlike its cousin the hairy slickster."
+msgstr ""
+"乙醇浮油生物是一种黏滑的小动物，能够消耗<link=“CARBONDIOXIDE”>二氧化碳</"
+"link> 并排出<link=“ETHANOL”>乙醇</link>。\n"
+"\n"
+"与其近亲毛茸浮油生物不同，乙醇浮油生物已经适应了富含二氧化碳的寒冷环境。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.EGG_NAME"
+msgid "<link=\"ETHANOLOILFLOATER\">Ethanol Slickster Egg</link>"
+msgstr "<link=\"ETHANOLOILFLOATER\">乙醇浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ETHANOL.NAME"
+msgid "<link=\"ETHANOLOILFLOATER\">Ethanol Slickster</link>"
+msgstr "<link=\"ETHANOLOILFLOATER\">乙醇浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.BABY.DESC"
+msgid ""
+"A goopy little Frozen Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the "
+"<link=\"FROZENOILFLOATER\">Frozen Slickster</link>."
+msgstr ""
+"一只黏糊糊的寒冻浮油生物幼崽。\n"
+"\n"
+"有一天它会成长为成年形态，<link=“FROZENOILFLOATER”>寒冻浮油生物</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.BABY.NAME"
+msgid "<link=\"FROZENOILFLOATER\">Frozen Larva</link>"
+msgstr "<link=\"FROZENOILFLOATER\">寒冻浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.DESC"
+msgid ""
+"<b><color=#70B5F9FF>Frozen Slicksters</color></b> are slimy critters that "
+"consume air to reject <link=\"OXYROCK\">Oxyrock</link> or "
+"<link=\"ANTIGEL\">Antigel</link>.\n"
+"\n"
+"The <b><color=#70B5F9FF>Frozen slickster</color></b> is a distant variant of "
+"the slickster in a <b><color=#70B5F9FF>very cold</color></b> environment, it "
+"produces a liquid appreciated by our engineers.\n"
+"\n"
+"The <b><color=#70B5F9FF>Frozen slickster</color></b>also has a slight "
+"cooling effect in its environment"
+msgstr ""
+"<b><color=#70B5F9FF>寒冻浮油生物</color></b>是一种黏滑的小动物，能吸收空气并"
+"排出<link=“OXYROCK”>氧石</link>或<link=“ANTIGEL”>抗冻剂。\n"
+"\n"
+"<b><color=#70B5F9FF>寒冻浮油生物</color></b>是生活在<b><color=#70B5F9FF>极寒"
+"</color></b>环境中的浮油生物远亲变种，它会生成一种深受我们工程师喜爱的液"
+"体。\n"
+"\n"
+"<b><color=#70B5F9FF>寒冻浮油生物</color></b>在其周围环境中还会带来一定的降温"
+"效果。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.EGG_NAME"
+msgid "<link=\"FROZENOILFLOATER\">Frozen Slickster Egg</link>"
+msgstr "<link=\"FROZENOILFLOATER\">寒冻浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_FROZEN.NAME"
+msgid "<link=\"FROZENOILFLOATER\">Frozen Slickster</link>"
+msgstr "<link=\"FROZENOILFLOATER\">寒冻浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.BABY.DESC"
+msgid ""
+"A goopy little Leafy Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the "
+"<link=\"LEAFYOILFLOATER\">Leafy Slickster</link>."
+msgstr ""
+"一只黏糊糊的绿叶浮油生物幼崽。\n"
+"\n"
+"有一天它会成长为成年形态，<link=“LEAFYOILFLOATER”>绿叶浮油生物</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.BABY.NAME"
+msgid "<link=\"LEAFYOILFLOATER\">Leafy Larva</link>"
+msgstr "<link=\"LEAFYOILFLOATER\">绿叶浮油生物幼崽</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.DESC"
+msgid ""
+"<b><color=#0ABC11FF>Leafy Slicksters</color></b> are leafy critters that "
+"consume impur air.\n"
+"\n"
+"The <b><color=#0ABC11FF>leafy slickster</color></b> has adapted to its "
+"environment and uses photosynthesis to feed on carbon.\n"
+"<b><color=#0ABC11FF>Leafy Slicksters</color></b> need "
+"<b><color=#D8B700FF>light</color></b> to live.\n"
+"\n"
+"<b><color=#0ABC11FF>Leafy slicksters</color></b> are loved by duplicants for "
+"their air-depolluting properties, while providing a sweet "
+"<link=\"POLLENGERMS\">Floral Scent</link>."
+msgstr ""
+"<b><color=#0ABC11FF>绿叶浮油生物</color></b>是一种叶状的小生物，能吸收污染空"
+"气。\n"
+"\n"
+"<b><color=#0ABC11FF>绿叶浮油生物</color></b>已适应其环境，通过光合作用以碳为"
+"食。\n"
+"<b><color=#0ABC11FF>绿叶浮油生物</color></b>需要<b><color=#D8B700FF>光照</"
+"color></b>才能生存。\n"
+"\n"
+"<b><color=#0ABC11FF>绿叶浮油生物</color></b>因其净化空气的特性而深受复制人的"
+"喜爱，同时还能散发甜美的<link=“POLLENGERMS”>花香</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.EGG_NAME"
+msgid "<link=\"LEAFYOILFLOATER\">Leafy Slickster Egg</link>"
+msgstr "<link=\"LEAFYOILFLOATER\">绿叶浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_LEAFY.NAME"
+msgid "<link=\"LEAFYOILFLOATER\">Leafy Slickster</link>"
+msgstr "<link=\"LEAFYOILFLOATER\">绿叶浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.BABY.DESC"
+msgid ""
+"A goopy little OwO Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the <link=\"OWOOILFLOATER\">OwO "
+"Slickster</link>."
+msgstr ""
+"一只黏糊糊的OwO浮油生物幼崽。\n"
+"\n"
+"有一天它会成长为成年形态，<link=“OWOOILFLOATER”>OwO浮油生物</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.BABY.NAME"
+msgid "<link=\"OWOOILFLOATER\">OwO Larva</link>"
+msgstr "<link=\"OWOOILFLOATER\">OwO浮油生物幼崽</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.DESC"
+msgid ""
+"OwO Slicksters are cute critters that consume <link=\"OXYGEN\">Oxygen</link> "
+"and exude <link=\"HYDROGEN\">Hydrogen</link>.\n"
+"The OwO Slicksters are extremely cute creatures that will delight your "
+"duplicants.\n"
+" Duplicants passing near an OwO Slickster earn the <link=\"OWOEFFECT\">OwO "
+"effect</link> reducing the stress.\n"
+msgstr ""
+"OwO浮油生物是一种可爱的小生物，能消耗<link=“OXYGEN”>氧气</link>并排出"
+"<link=“HYDROGEN”>氢气</link>。\n"
+"OwO浮油生物极其可爱，会让你的复制人感到愉悦。\n"
+"经过OwO浮油生物附近的复制人会获得<link=“OWOEFFECT”>OwO效果</link>，从而减少压"
+"力。\n"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.EGG_NAME"
+msgid "<link=\"OWOOILFLOATER\">OwO Slickster Egg</link>"
+msgstr "<link=\"OWOOILFLOATER\">OwO浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_OWO.NAME"
+msgid "<link=\"OWOOILFLOATER\">OwO Slickster</link>"
+msgstr "<link=\"OWOOILFLOATER\">OwO浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.BABY.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.BABY.DESC"
+msgid ""
+"A goopy little Robot Larva.\n"
+"\n"
+"One day it will grow into an adult morph, the "
+"<link=\"ROBOTOILFLOATER\">Robot Slickster</link>."
+msgstr ""
+"一只黏糊糊的机械浮油生物幼崽。\n"
+"\n"
+"有一天它会成长为成年形态，<link=“ROBOTOILFLOATER”>机械浮油生物</link>。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.BABY.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.BABY.NAME"
+msgid "<link=\"ROBOTOILFLOATER\">Robot Larva</link>"
+msgstr "<link=\"ROBOTOILFLOATER\">机械浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.DESC"
+msgid ""
+"Robot Slicksters are slimy critters that consume hot "
+"<link=\"CARBONDIOXIDE\">Carbon Dioxide</link>, <link=\"STEAM\">Steam</link> "
+"or <link=\"SOURGAS\">Sour Gas</link> and exude <link=\"STEEL\">Steel</"
+"link>.\n"
+"\n"
+"The robot slickster is a slime that has been technologically improved by "
+"Gravitas to meet our heavy metal needs."
+msgstr ""
+"机械浮油生物是一种黏滑的小生物，能消耗高温的<link=“CARBONDIOXIDE”>二氧化碳</"
+"link>、<link=“STEAM”>蒸汽</link>或<link=“SOURGAS”>高硫天然气</link>，并排出"
+"<link=“STEEL”>钢铁。\n"
+"\n"
+"机械浮油生物是一种经过庄严科技技术改良的黏液生物，以满足我们的重金属需求。"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.EGG_NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.EGG_NAME"
+msgid "<link=\"ROBOTOILFLOATER\">Robot Slickster Egg</link>"
+msgstr "<link=\"ROBOTOILFLOATER\">机械浮油生物蛋</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.VARIANT_ROBOT.NAME"
+msgid "<link=\"ROBOTOILFLOATER\">Robot Slickster</link>"
+msgstr "<link=\"ROBOTOILFLOATER\">机械浮油生物</link>"
+
+#. ILoveSlicksters.PHO_STRINGS.WORLDGEN.DESC
+msgctxt "ILoveSlicksters.PHO_STRINGS.WORLDGEN.DESC"
+msgid ""
+"Slicksteria is an asteroid very close to Verdante but which has the "
+"particularity of containing a great diversity of slicksters, the conditions "
+"on this asteroid are perfect for their development and these small bugs will "
+"help your colony to survive.\n"
+"\n"
+msgstr ""
+"浮油生物星是一个靠近翠绿星体的小行星，其特殊之处在于拥有丰富多样的浮油生物。"
+"这颗小行星的环境条件非常适合它们的生长，这些小生物将帮助你的殖民地生存下"
+"去。\n"
+"\n"
+
+#. ILoveSlicksters.PHO_STRINGS.WORLDGEN.NAME
+msgctxt "ILoveSlicksters.PHO_STRINGS.WORLDGEN.NAME"
+msgid "Slicksteria"
+msgstr "浮油生物星"


### PR DESCRIPTION
Thanks for the great mod, I also love slicksters! Add a Chinese - Simplified translation.



Also allow me to offer a more reasonable Chinese translation for your steam workshop:

---------------------------------------------------

我爱浮游生物 - 更多变种！（I Love Slicksters - Morphs !）


浮油生物实在太可爱了，应该拥有更多变种
这个模组添加了大量浮油生物形态，并提升了它们的摄取量

细节
模组可以提高浮油生物的摄取量（每周期60千克而不是20千克），启用后，三只旧版浮油生物的产量才等于一只新浮油生物
它们会更有用养殖也会减少卡顿
可以通过选项关闭此功能

模组在分子熔炉中添加了新的配方，使部分浮油生物变种更容易获得

模组增强了长毛浮油生物
 - 现在它会排出氧气（你可以在配置文件中修改它的食谱）
 - 死亡时掉落芦苇纤维

模组将自定义浮油生物及其蛋添加到了补给包裹中

浮油生物星基于乔木小行星，整体生态群落和难度一致，但自然浮油生物更多
浮油生物星尺寸为 256x288

乙醇浮油生物
二氧化碳 => 乙醇

OwO 浮油生物
氧气 => 氢气
赋予小人减压的 OwO 效果与装饰度

绿叶浮油生物
像植物一样！需要光照，死亡时掉落花朵并释放花香孢子
二氧化碳 => 氧气
氯气 => 藻类
氧气 => 磷矿
天然气 => 煤炭

机械浮油生物
死亡时掉落钢铁，并释放少量僵尸孢子
二氧化碳 => 钢
蒸汽 => 钢
高硫天然气 => 钢

寒冻浮油生物
二氧化碳 => 抗冻剂
氧气 => 氧石
抗冻剂是一种有趣的新型热力流体

水栖浮油生物
像鱼一样！只能生活在水中（干净水、盐水、污水或抗冻剂）
死亡时掉落鱼肉，在水族箱中（密闭含水房间）可被驯化
水 => 天然气
污染水 => 菌泥
抗冻剂 => 黑钨矿
盐水/浓盐水 => 沉积岩

构想
添加一个浮油生物星球特质

链接
我的 Github: https://github.com/Pholith/ONI-Mods
我的 Discord: https://discord.gg/cmZUWYT
我的 Patreon: https://www.patreon.com/pholithmods
想翻译这个模组？请查看这里的步骤: https://github.com/Pholith/ONI-Mods/blob/master/README.md#want-to-translate-my-mods-in-your-languages-

感谢 Kaatoon 提供机械、绿叶和寒冻浮油生物
感谢 Erny 提供水栖浮油生物

---------------------------------------------------
